### PR TITLE
Two small nitpicks

### DIFF
--- a/templates/_geojson.twig
+++ b/templates/_geojson.twig
@@ -27,7 +27,7 @@
 <fieldset class="form-group bolt-field-geojson">
     <legend class="sr-only">{{field.label|default(key)}}</legend>
     <label class="main col-xs-12 control-label control-label">{{field.label|default(key)}}
-        {% if field.info is not empty %}
+        {% if field.info|default(false) %}
         <i class="info-pop fa fa-info-circle" data-content="{{ field.info|escape('html_attr') }}" data-html="1" data-title="Image list" data-original-title="" title=""><span class="sr-only">Info</span></i>
         {% endif %}
     </label>

--- a/web/run.js
+++ b/web/run.js
@@ -67,7 +67,7 @@
             if (defaults.hasOwnProperty('geojsonfieldStyle') )     { this.settings.style = defaults.geojsonfieldStyle; }
         },
         createMap: function() {
-            var osmUrl    = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            var osmUrl    = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                 osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
                 osm       = L.tileLayer(osmUrl, {
                                 maxZoom:     this.settings.maxzoom,


### PR DESCRIPTION
Great looking extension, I just have two small nitpicks I thought I'd submit fixes for to you :)
- If the info key is not set and strict variables is turned on the editcontent page will 500
- Load map tiles over https to avoid security warnings when the site is loaded over https. Will still work fine on http.
